### PR TITLE
Changed narrowcasting naming in package.json to aurora naming convention

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint-fix": "eslint ./src --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore ",
     "format": "prettier --ignore-path .gitignore --check ./src/",
     "format-fix": "prettier --ignore-path .gitignore --write ./src/",
-    "gen-client": "openapi --input ../narrowcasting-core/build/swagger.json --output src/api/ --useUnionTypes",
+    "gen-client": "openapi --input ../aurora-core/build/swagger.json --output src/api/ --useUnionTypes",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
Same as in https://github.com/GEWIS/aurora-backoffice/commit/133b1e54a76afff4a636ddbc066c09a7b249ee3e where the naming was already changed but now the client can also be generated in the new namespace