### PR TITLE
feat(orders): add a new global order number overview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,9 @@
 import './index.css';
 import { BrowserRouter } from 'react-router-dom';
 import AuthContextProvider from './contexts/AuthContext';
-import HandlerSwitcher from './HandlerSwitcher';
 import ErrorBoundary from './ErrorBoundary';
 import { client } from './api';
-
+import ClientView from './ClientView';
 export default function App() {
   client.setConfig({
     baseUrl: '/api',
@@ -14,7 +13,7 @@ export default function App() {
     <ErrorBoundary>
       <BrowserRouter>
         <AuthContextProvider>
-          <HandlerSwitcher />
+          <ClientView />
         </AuthContextProvider>
       </BrowserRouter>
     </ErrorBoundary>

--- a/src/ClientView.tsx
+++ b/src/ClientView.tsx
@@ -1,0 +1,49 @@
+import { useContext, useEffect, useState } from 'react';
+import { Socket } from 'socket.io-client';
+import OrdersOverlay from './overlays/OrdersOverlay';
+import HandlerSwitcher from './HandlerSwitcher';
+import { AuthContext } from './contexts/AuthContext';
+import registerScreenHandler from './events/screenHandler';
+import { LoadingView, ReloadCountdown } from './handlers/default';
+
+export default function ClientView() {
+  const [screenSocket, setScreenSocket] = useState<Socket | null>(null);
+
+  const { user, loading } = useContext(AuthContext);
+
+  useEffect(() => {
+    if (!user) return;
+    registerScreenHandler(setScreenSocket);
+  }, [user]);
+
+  if (loading) {
+    return (
+      <LoadingView>
+        <h1 className="text-8xl">Initializing the screen...</h1>
+      </LoadingView>
+    );
+  }
+
+  if (!user) {
+    return (
+      <LoadingView>
+        <h1 className="text-8xl">Unauthenticated</h1>
+        <ReloadCountdown />
+      </LoadingView>
+    );
+  }
+
+  if (!screenSocket) {
+    return (
+      <LoadingView>
+        <h1 className="text-8xl">Connecting to websocket...</h1>
+      </LoadingView>
+    );
+  }
+  return (
+    <>
+      <OrdersOverlay socket={screenSocket} />
+      <HandlerSwitcher socket={screenSocket} />
+    </>
+  );
+}

--- a/src/HandlerSwitcher.tsx
+++ b/src/HandlerSwitcher.tsx
@@ -1,13 +1,11 @@
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Socket } from 'socket.io-client';
 import registerRootHandler from './events/rootHandler';
-import registerScreenHandler from './events/screenHandler';
 import './index.css';
 
 import { default as CenturionView } from './handlers/centurion';
 import { default as SpotifyView } from './handlers/spotify';
-import { default as DefaultView, LoadingView, ReloadCountdown } from './handlers/default';
-import { AuthContext } from './contexts/AuthContext';
+import { default as DefaultView } from './handlers/default';
 import StageEffectsView from './handlers/stage-effects';
 import TimeTrailRaceView from './handlers/time-trail-race';
 import PosterGewisView from './handlers/poster/gewis';
@@ -24,56 +22,30 @@ export enum Handlers {
   ROOM_RESPONSIBLE_LEGACY = 'RoomResponsibleLegacyHandler',
 }
 
-export default function HandlerSwitcher() {
-  const [currentHandler, setCurrentHandler] = useState<Handlers | null>(null);
-  const [screenSocket, setScreenSocket] = useState<Socket | null>(null);
+interface Props {
+  socket: Socket;
+}
 
-  const { user, loading } = useContext(AuthContext);
+export default function HandlerSwitcher({ socket }: Props) {
+  const [currentHandler, setCurrentHandler] = useState<Handlers | null>(null);
 
   useEffect(() => {
-    if (!user) return;
     registerRootHandler(setCurrentHandler);
-    registerScreenHandler(setScreenSocket);
-  }, [user]);
-
-  if (loading) {
-    return (
-      <LoadingView>
-        <h1 className="text-8xl">Initializing the screen...</h1>
-      </LoadingView>
-    );
-  }
-
-  if (!user) {
-    return (
-      <LoadingView>
-        <h1 className="text-8xl">Unauthenticated</h1>
-        <ReloadCountdown />
-      </LoadingView>
-    );
-  }
-
-  if (!screenSocket) {
-    return (
-      <LoadingView>
-        <h1 className="text-8xl">Connecting to websocket...</h1>
-      </LoadingView>
-    );
-  }
+  }, []);
 
   switch (currentHandler) {
     case Handlers.CENTURION:
-      return <CenturionView socket={screenSocket} />;
+      return <CenturionView socket={socket} />;
     case Handlers.SPOTIFY:
-      return <SpotifyView socket={screenSocket} />;
+      return <SpotifyView socket={socket} />;
     case Handlers.GEWIS_POSTER:
       return <PosterGewisView />;
     case Handlers.HUBBLE_POSTER:
       return <PosterHubbleView />;
     case Handlers.STAGE_EFFECTS:
-      return <StageEffectsView socket={screenSocket} />;
+      return <StageEffectsView socket={socket} />;
     case Handlers.TIME_TRAIL_RACE:
-      return <TimeTrailRaceView socket={screenSocket} />;
+      return <TimeTrailRaceView socket={socket} />;
     case Handlers.ROOM_RESPONSIBLE_LEGACY:
       return <RoomResponsibleLegacyView />;
     default:

--- a/src/components/OrderList.tsx
+++ b/src/components/OrderList.tsx
@@ -11,7 +11,7 @@ export default function OrderList({ orders }: Props) {
     <div className="absolute top-0 right-0 z-50 m-4 text-white" style={{ height: '85%', fontSize: '5.5vh' }}>
       {orders.length > 0 && (
         <div>
-          <div className="top-0 right-0 mb-4 bg-opacity-80 bg-gray-400 p-4 rounded-lg text-right">Ready</div>
+          <div className="top-0 right-0 mb-4 bg-opacity-80 bg-gray-400 p-4 rounded-lg text-center">Ready</div>
           <div
             className="grid grid-flow-col-dense gap-4"
             style={{ gridTemplateRows: 'repeat(6, minmax(0, 1fr))' }}

--- a/src/components/OrderList.tsx
+++ b/src/components/OrderList.tsx
@@ -1,14 +1,11 @@
-import { useEffect } from 'react';
+// import { useEffect } from 'react';
+import { Order } from '../api';
 
 interface Props {
-  orders: string[];
+  orders: Order[];
 }
 
-export default function HubbleOrderView({ orders }: Props) {
-  useEffect(() => {
-    //   Do something when the orders change
-  }, [orders]);
-
+export default function OrderList({ orders }: Props) {
   return (
     // bg-blue-500
     <div className="absolute top-0 right-0 z-50 m-4 text-white" style={{ height: '85%', fontSize: '5.5vh' }}>
@@ -22,7 +19,7 @@ export default function HubbleOrderView({ orders }: Props) {
           >
             {orders.map((order, index) => (
               <div key={index} className="bg-gray-400 p-4 bg-opacity-80 rounded-lg text-center animate-slide-in">
-                {order}
+                {order.number}
               </div>
             ))}
           </div>

--- a/src/handlers/poster/hubble/components/OverlayHubble.tsx
+++ b/src/handlers/poster/hubble/components/OverlayHubble.tsx
@@ -1,7 +1,5 @@
 import { OverlayProps } from '../../index';
 import HubbleProgressBar from './HubbleProgressBar';
-import HubbleOrderView from './HubbleOrderView';
-
 export default function OverlayHubble({ poster, seconds, posterIndex, nextPoster, pausePoster }: OverlayProps) {
   return (
     <>
@@ -13,7 +11,6 @@ export default function OverlayHubble({ poster, seconds, posterIndex, nextPoster
         nextPoster={nextPoster}
         pausePoster={pausePoster}
       />
-      <HubbleOrderView orders={['001', '002']} />
     </>
   );
 }

--- a/src/overlays/OrdersOverlay.tsx
+++ b/src/overlays/OrdersOverlay.tsx
@@ -1,0 +1,35 @@
+import { Socket } from 'socket.io-client';
+import { useEffect, useState } from 'react';
+import { Order } from '../api';
+import OrderList from '../components/OrderList';
+
+interface Props {
+  socket: Socket;
+}
+
+export default function OrdersOverlay({ socket }: Props) {
+  const [orders, setOrders] = useState<Order[]>([
+    {
+      number: -420,
+      startTime: new Date().toISOString(),
+      timeoutSeconds: 3600,
+    },
+    {
+      number: -69,
+      startTime: new Date().toISOString(),
+      timeoutSeconds: 3600,
+    },
+  ]);
+
+  useEffect(() => {
+    socket.on('orders', (newOrderSet) => {
+      setOrders(newOrderSet[0].orders);
+    });
+
+    return () => {
+      socket.removeAllListeners();
+    };
+  }, [socket]);
+
+  return <OrderList orders={orders} />;
+}

--- a/src/overlays/OrdersOverlay.tsx
+++ b/src/overlays/OrdersOverlay.tsx
@@ -24,12 +24,14 @@ export default function OrdersOverlay({ socket }: Props) {
         console.error(err);
       });
 
-    socket.on('orders', (newOrderSet) => {
-      setOrders((newOrderSet as ShowOrdersEvent[])[0].orders);
-    });
+    const newOrdersCallback = (newOrderSet: ShowOrdersEvent[]) => {
+      setOrders(newOrderSet[0].orders);
+    };
+
+    socket.on('orders', newOrdersCallback);
 
     return () => {
-      socket.removeAllListeners();
+      socket.off('orders', newOrdersCallback);
     };
   }, [socket]);
 

--- a/src/overlays/OrdersOverlay.tsx
+++ b/src/overlays/OrdersOverlay.tsx
@@ -1,6 +1,6 @@
 import { Socket } from 'socket.io-client';
 import { useCallback, useEffect, useState } from 'react';
-import { Order } from '../api';
+import { getAllOrders, Order } from '../api';
 import OrderList from '../components/OrderList';
 
 interface Props {
@@ -8,20 +8,14 @@ interface Props {
 }
 
 export default function OrdersOverlay({ socket }: Props) {
-  const [orders, setOrders] = useState<Order[]>([
-    {
-      number: -420,
-      startTime: new Date().toISOString(),
-      timeoutSeconds: 3600,
-    },
-    {
-      number: -69,
-      startTime: new Date().toISOString(),
-      timeoutSeconds: 3600,
-    },
-  ]);
+  const [orders, setOrders] = useState<Order[]>([]);
 
   useEffect(() => {
+    getAllOrders().then((ordersRes) => {
+      if (!ordersRes.data) return;
+      setOrders(ordersRes.data);
+    });
+
     socket.on('orders', (newOrderSet) => {
       setOrders(newOrderSet[0].orders);
     });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->
Adds the Hubble order overlay by adding a new overlay layer

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
![image](https://github.com/user-attachments/assets/662a9987-87f0-499d-ae27-bec6c7f64ac0)
The client retrieves the orders via socketio, and removes them after the timeout. The order overlay is visible through all handlers

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_