### PR TITLE
feat(orders): improved order card styling including new animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@hey-api/client-fetch": "^0.8.3",
     "@tailwindcss/postcss": "^4.0.15",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.5.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-helmet": "^6.1.0",

--- a/src/components/GlassCard.tsx
+++ b/src/components/GlassCard.tsx
@@ -1,0 +1,14 @@
+import { PropsWithChildren, HTMLAttributes } from 'react';
+
+interface Props extends PropsWithChildren, HTMLAttributes<HTMLDivElement> {}
+
+export default function GlassCard({ children, className, ...props }: Props) {
+  return (
+    <div
+      className={`bg-gray-800/50 rounded-md bg-clip-padding backdrop-filter backdrop-blur-md border border-gray-100 ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/OrderList.tsx
+++ b/src/components/OrderList.tsx
@@ -1,4 +1,4 @@
-// import { useEffect } from 'react';
+import { AnimatePresence, motion, TargetAndTransition } from 'framer-motion';
 import { Order } from '../api';
 import GlassCard from './GlassCard';
 
@@ -7,25 +7,43 @@ interface Props {
 }
 
 export default function OrderList({ orders }: Props) {
+  const animationInitial: TargetAndTransition = {
+    scale: 0,
+  };
+  const animationIn: TargetAndTransition = {
+    scale: 1,
+    transition: { delay: 0.5, type: 'spring' },
+  };
+  const animationOut: TargetAndTransition = {
+    opacity: 0,
+    transition: { delay: 0.5 },
+  };
+
   return (
     // bg-blue-500
     <div className="absolute top-0 right-0 z-50 m-4 text-white" style={{ height: '85%', fontSize: '5.5vh' }}>
-      {orders.length > 0 && (
-        <div>
-          <GlassCard className="top-0 right-0 mb-4 px-6 py-4 text-center">Ready</GlassCard>
-          <div
-            className="grid grid-flow-col-dense gap-4"
-            style={{ gridTemplateRows: 'repeat(6, minmax(0, 1fr))' }}
-            dir="rtl"
-          >
-            {orders.map((order, index) => (
-              <GlassCard key={index} className="text-center p-4">
-                {order.number}
-              </GlassCard>
+      <div>
+        <AnimatePresence>
+          {orders.length > 0 && (
+            <motion.div initial={animationInitial} animate={animationIn} exit={animationOut}>
+              <GlassCard className="top-0 right-0 mb-4 px-6 py-4 text-center">Ready</GlassCard>
+            </motion.div>
+          )}
+        </AnimatePresence>
+        <ul
+          className="grid grid-flow-col-dense gap-4"
+          style={{ gridTemplateRows: 'repeat(6, minmax(0, 1fr))' }}
+          dir="rtl"
+        >
+          <AnimatePresence>
+            {orders.map((order) => (
+              <motion.li key={order.number} initial={animationInitial} animate={animationIn} exit={animationOut} layout>
+                <GlassCard className="text-center p-4">{order.number}</GlassCard>
+              </motion.li>
             ))}
-          </div>
-        </div>
-      )}
+          </AnimatePresence>
+        </ul>
+      </div>
     </div>
   );
 }

--- a/src/components/OrderList.tsx
+++ b/src/components/OrderList.tsx
@@ -1,5 +1,6 @@
 // import { useEffect } from 'react';
 import { Order } from '../api';
+import GlassCard from './GlassCard';
 
 interface Props {
   orders: Order[];
@@ -11,16 +12,16 @@ export default function OrderList({ orders }: Props) {
     <div className="absolute top-0 right-0 z-50 m-4 text-white" style={{ height: '85%', fontSize: '5.5vh' }}>
       {orders.length > 0 && (
         <div>
-          <div className="top-0 right-0 mb-4 bg-opacity-80 bg-gray-400 p-4 rounded-lg text-center">Ready</div>
+          <GlassCard className="top-0 right-0 mb-4 px-6 py-4 text-center">Ready</GlassCard>
           <div
             className="grid grid-flow-col-dense gap-4"
             style={{ gridTemplateRows: 'repeat(6, minmax(0, 1fr))' }}
             dir="rtl"
           >
             {orders.map((order, index) => (
-              <div key={index} className="bg-gray-400 p-4 bg-opacity-80 rounded-lg text-center animate-slide-in">
+              <GlassCard key={index} className="text-center p-4">
                 {order.number}
-              </div>
+              </GlassCard>
             ))}
           </div>
         </div>

--- a/src/components/OrderList.tsx
+++ b/src/components/OrderList.tsx
@@ -38,7 +38,7 @@ export default function OrderList({ orders }: Props) {
           <AnimatePresence>
             {orders.map((order) => (
               <motion.li key={order.number} initial={animationInitial} animate={animationIn} exit={animationOut} layout>
-                <GlassCard className="text-center p-[1.5vh] min-w-[7vw]">{order.number}</GlassCard>
+                <GlassCard className="text-center p-[1.5vh] min-w-[2.3em]">{order.number}</GlassCard>
               </motion.li>
             ))}
           </AnimatePresence>

--- a/src/components/OrderList.tsx
+++ b/src/components/OrderList.tsx
@@ -21,24 +21,24 @@ export default function OrderList({ orders }: Props) {
 
   return (
     // bg-blue-500
-    <div className="absolute top-0 right-0 z-50 m-4 text-white" style={{ height: '85%', fontSize: '5.5vh' }}>
+    <div className="absolute top-0 right-0 z-50 m-[1.5vh] text-white" style={{ height: '85%', fontSize: '5.5vh' }}>
       <div>
         <AnimatePresence>
           {orders.length > 0 && (
             <motion.div initial={animationInitial} animate={animationIn} exit={animationOut}>
-              <GlassCard className="top-0 right-0 mb-4 px-6 py-4 text-center">Ready</GlassCard>
+              <GlassCard className="top-0 right-0 mb-[1.5vh] px-[2vh] py-[1.5vh] text-center">Ready</GlassCard>
             </motion.div>
           )}
         </AnimatePresence>
         <ul
-          className="grid grid-flow-col-dense gap-4"
+          className="grid grid-flow-col-dense gap-[1.5vh]"
           style={{ gridTemplateRows: 'repeat(6, minmax(0, 1fr))' }}
           dir="rtl"
         >
           <AnimatePresence>
             {orders.map((order) => (
               <motion.li key={order.number} initial={animationInitial} animate={animationIn} exit={animationOut} layout>
-                <GlassCard className="text-center p-4">{order.number}</GlassCard>
+                <GlassCard className="text-center p-[1.5vh] min-w-[7vw]">{order.number}</GlassCard>
               </motion.li>
             ))}
           </AnimatePresence>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6066,6 +6066,15 @@ fraction.js@^4.3.7:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.3.7.tgz#06ca0085157e42fda7f9e726e79fefc4068840f7"
   integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
 
+framer-motion@^12.5.0:
+  version "12.5.0"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-12.5.0.tgz#3201f92d7a00f7ab636c39fdb619b07247f05a8b"
+  integrity sha512-buPlioFbH9/W7rDzYh1C09AuZHAk2D1xTA1BlounJ2Rb9aRg84OXexP0GLd+R83v0khURdMX7b5MKnGTaSg5iA==
+  dependencies:
+    motion-dom "^12.5.0"
+    motion-utils "^12.5.0"
+    tslib "^2.4.0"
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -8113,6 +8122,18 @@ mlly@^1.7.1, mlly@^1.7.4:
     pathe "^2.0.1"
     pkg-types "^1.3.0"
     ufo "^1.5.4"
+
+motion-dom@^12.5.0:
+  version "12.5.0"
+  resolved "https://registry.yarnpkg.com/motion-dom/-/motion-dom-12.5.0.tgz#38beabafa11c068f09c2b096674b2d46025a0a24"
+  integrity sha512-uH2PETDh7m+Hjd1UQQ56yHqwn83SAwNjimNPE/kC+Kds0t4Yh7+29rfo5wezVFpPOv57U4IuWved5d1x0kNhbQ==
+  dependencies:
+    motion-utils "^12.5.0"
+
+motion-utils@^12.5.0:
+  version "12.5.0"
+  resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-12.5.0.tgz#0e42a6b8030327166ca0d0ea0d5b86d64c21e51d"
+  integrity sha512-+hFFzvimn0sBMP9iPxBa9OtRX35ZQ3py0UHnb8U29VD+d8lQ8zH3dTygJWqK7av2v6yhg7scj9iZuvTS0f4+SA==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Gives the orders on screen a more modern look. Furthermore, the individual cards are now animated, meaning they "pop in" when a new order gets added to the list and they "fade out" when they expire. Furthermore, the gap between cards getting smaller at higher screen resolutions, should now be fixed. The cards should now be truly the same size and layout at any screen size.

![image](https://github.com/user-attachments/assets/6da153ae-136d-47a0-a998-5a4d447eda6f)

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_