### PR TITLE
feat(posters): add Aurora watermark to first poster in carousel

### DIFF
--- a/src/handlers/poster/components/ProgressBar.tsx
+++ b/src/handlers/poster/components/ProgressBar.tsx
@@ -1,3 +1,4 @@
+import { LogoLine } from '../../../components/aurora-logos/LogoLine';
 import ProgressBarSlider from './ProgressBarSlider';
 import Clock from './Clock';
 
@@ -31,54 +32,61 @@ export default function ProgressBar({
   progressBarColor = '#c40000',
 }: Props) {
   return (
-    <div
-      className="absolute w-full bottom-0 z-50 text-white flex flex-col text-5xl progress-bar-height"
-      id="progress-bar"
-      style={{ backgroundColor: !minimal && !hide ? 'rgba(0, 0, 0, 0.5)' : '' }}
-    >
-      <div className="absolute w-full" style={{ bottom: minimal || hide ? 0 : '' }} id="progress-bar-slider-outer">
-        {seconds !== undefined && posterIndex !== undefined && (
-          <ProgressBarSlider seconds={seconds} posterIndex={posterIndex} color={progressBarColor} />
-        )}
-      </div>
+    <div className="absolute w-full bottom-0 z-50">
+      {posterIndex === 0 && (
+        <div className="mb-4 opacity-50" id="aurora-watermark">
+          <LogoLine variant="left" size="2em" dark />
+        </div>
+      )}
       <div
-        className={`flex-grow flex justify-center items-center h-full ${hide ? 'hidden' : ''}`}
-        id="progress-bar-container"
+        className="relative text-white flex flex-col text-5xl progress-bar-height"
+        id="progress-bar"
+        style={{ backgroundColor: !minimal && !hide ? 'rgba(0, 0, 0, 0.5)' : '' }}
       >
-        <div className="relative py-3" id="progress-bar-logos">
-          <div className="h-full flex flex-row gap-6 items-center">
-            {logo && (
-              <>
-                <svg style={{ filter: 'drop-shadow(3px 5px 2px rgb(0 0 0 /0.4))' }} viewBox="0 0 50 100">
-                  <image x="0" y="0" height="100%" width="100%" xlinkHref={logo} />
-                </svg>
-                {borrelMode && (
-                  <svg
-                    style={{
-                      filter: 'brightness(0) invert(1) drop-shadow(3px 5px 2px rgb(0 0 0 /0.4))',
-                    }}
-                    viewBox="0 0 100 100"
-                    id="progress-bar-logo-borrelmode"
-                  >
-                    <image x="0" y="0" height="100%" width="100%" xlinkHref={'/borrel/sudosos.svg'} />
-                  </svg>
-                )}
-              </>
-            )}
-          </div>
+        <div className="absolute w-full" style={{ bottom: minimal || hide ? 0 : '' }} id="progress-bar-slider-outer">
+          {seconds !== undefined && posterIndex !== undefined && (
+            <ProgressBarSlider seconds={seconds} posterIndex={posterIndex} color={progressBarColor} />
+          )}
         </div>
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
         <div
-          className="flex-grow text-center text-shadow whitespace-nowrap overflow-hidden text-ellipsis"
-          style={{ minHeight: '1em' }}
-          onClick={pausePoster}
-          id="progress-bar-title"
+          className={`flex-grow flex justify-center items-center h-full ${hide ? 'hidden' : ''}`}
+          id="progress-bar-container"
         >
-          {!minimal && title}
-        </div>
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-        <div className="text-right" onClick={nextPoster} id="progress-bar-clock">
-          <Clock color={clockColor} shouldTick={clockTick} />
+          <div className="relative py-3" id="progress-bar-logos">
+            <div className="h-full flex flex-row gap-6 items-center">
+              {logo && (
+                <>
+                  <svg style={{ filter: 'drop-shadow(3px 5px 2px rgb(0 0 0 /0.4))' }} viewBox="0 0 50 100">
+                    <image x="0" y="0" height="100%" width="100%" xlinkHref={logo} />
+                  </svg>
+                  {borrelMode && (
+                    <svg
+                      style={{
+                        filter: 'brightness(0) invert(1) drop-shadow(3px 5px 2px rgb(0 0 0 /0.4))',
+                      }}
+                      viewBox="0 0 100 100"
+                      id="progress-bar-logo-borrelmode"
+                    >
+                      <image x="0" y="0" height="100%" width="100%" xlinkHref={'/borrel/sudosos.svg'} />
+                    </svg>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
+          <div
+            className="flex-grow text-center text-shadow whitespace-nowrap overflow-hidden text-ellipsis"
+            style={{ minHeight: '1em' }}
+            onClick={pausePoster}
+            id="progress-bar-title"
+          >
+            {!minimal && title}
+          </div>
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
+          <div className="text-right" onClick={nextPoster} id="progress-bar-clock">
+            <Clock color={clockColor} shouldTick={clockTick} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/handlers/poster/poster.css
+++ b/src/handlers/poster/poster.css
@@ -7,6 +7,12 @@
 #poster #progress-bar {
 }
 
+/* Aurora Watermark shown on the first poster of the carousel. Hidden otherwise */
+#poster #progress-bar #watermark {
+  /*You probably want to set some custom size if you rescale everything
+  /*font-size: '2em';*/
+}
+
 /* The full-width box the slider is contained in */
 #poster #progress-bar #progress-bar-slider-outer {
   height: 6.25%;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds a small Aurora watermark to every first poster in the CarouselPosterHandler to show what amazing software is being used for the narrowcasting screen one's looking at.

![image](https://github.com/user-attachments/assets/269e5f69-14ea-452e-ad33-10cde9102a96)

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_