### PR TITLE
feat(spotify): add overlay to show the now-playing song

### DIFF
--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -30,7 +30,7 @@ export default class ErrorBoundary extends Component<Props, State> {
           <p>
             {this.state.error.name}: {this.state.error.message}
           </p>
-          {this.state.stack && <p>{this.state.stack}</p>}
+          {this.state.stack && <p className="whitespace-pre-line">{this.state.stack}</p>}
         </div>
       );
     }

--- a/src/HandlerSwitcher.tsx
+++ b/src/HandlerSwitcher.tsx
@@ -39,7 +39,7 @@ export default function HandlerSwitcher({ socket }: Props) {
     case Handlers.SPOTIFY:
       return <SpotifyView socket={socket} />;
     case Handlers.CAROUSEL_POSTER:
-      return <CarouselPosterView />;
+      return <CarouselPosterView socket={socket} />;
     case Handlers.STATIC_POSTER:
       return <StaticPosterView socket={socket} />;
     case Handlers.STAGE_EFFECTS:

--- a/src/handlers/poster/CarouselPosterView.tsx
+++ b/src/handlers/poster/CarouselPosterView.tsx
@@ -1,21 +1,17 @@
 import './components/index.scss';
 import { useEffect, useState } from 'react';
+import { Socket } from 'socket.io-client';
 import { getPosters, getPosterSettings, Poster, PosterScreenSettingsResponse } from '../../api';
+import ChangeTrackOverlay from '../../overlays/ChangeTrackOverlay';
 import PosterCarousel from './components/Carousel';
 import ProgressBar from './components/ProgressBar';
 import { URL_CUSTOM_STYLESHEET, URL_PROGRESS_BAR_LOGO } from './constants';
 
-export interface OverlayProps {
-  poster?: Poster;
-  posterTitle: string;
-  seconds?: number;
-  posterIndex?: number;
-  nextPoster: () => void;
-  pausePoster: () => void;
-  borrelMode?: boolean;
+interface Props {
+  socket: Socket;
 }
 
-export default function CarouselPosterView() {
+export default function CarouselPosterView({ socket }: Props) {
   const [settings, setSettings] = useState<PosterScreenSettingsResponse | undefined>();
   const [posters, setPosters] = useState<Poster[]>();
   const [borrelMode, setBorrelMode] = useState(false);
@@ -93,32 +89,35 @@ export default function CarouselPosterView() {
   const selectedPoster = posters && posters.length > 0 && posterIndex !== undefined ? posters[posterIndex] : undefined;
 
   return (
-    <div
-      className="h-screen w-screen bg-center bg-cover bg-no-repeat"
-      style={{ backgroundImage: 'url("base/poster-background.png")' }}
-      id="poster"
-    >
-      <link rel="stylesheet" href="/src/handlers/poster/poster.css" />
-      {/* Custom stylesheet should be imported AFTER the base stylesheet,
+    <>
+      <div
+        className="h-screen w-screen bg-center bg-cover bg-no-repeat"
+        style={{ backgroundImage: 'url("base/poster-background.png")' }}
+        id="poster"
+      >
+        <link rel="stylesheet" href="/src/handlers/poster/poster.css" />
+        {/* Custom stylesheet should be imported AFTER the base stylesheet,
       because the precedence is that the last CSS definition will be used */}
-      {settings?.stylesheet && <link rel="stylesheet" href={URL_CUSTOM_STYLESHEET} />}
-      <div className="overflow-hidden w-full h-full">
-        <PosterCarousel posters={posters || []} currentPoster={!posterIndex ? 0 : posterIndex} setTitle={setTitle} />
-        <ProgressBar
-          // poster={selectedPoster}
-          title={title}
-          seconds={posterTimeout !== undefined ? selectedPoster?.timeout : undefined}
-          posterIndex={posterIndex}
-          minimal={settings?.defaultMinimal}
-          nextPoster={nextPoster}
-          pausePoster={pausePoster}
-          borrelMode={borrelMode}
-          logo={settings?.progressBarLogo ? URL_PROGRESS_BAR_LOGO : ''}
-          progressBarColor={selectedPoster?.color || settings?.defaultProgressBarColor}
-          clockColor={selectedPoster?.color}
-          clockTick={settings?.clockShouldTick}
-        />
+        {settings?.stylesheet && <link rel="stylesheet" href={URL_CUSTOM_STYLESHEET} />}
+        <div className="overflow-hidden w-full h-full">
+          <PosterCarousel posters={posters || []} currentPoster={!posterIndex ? 0 : posterIndex} setTitle={setTitle} />
+          <ProgressBar
+            // poster={selectedPoster}
+            title={title}
+            seconds={posterTimeout !== undefined ? selectedPoster?.timeout : undefined}
+            posterIndex={posterIndex}
+            minimal={settings?.defaultMinimal}
+            nextPoster={nextPoster}
+            pausePoster={pausePoster}
+            borrelMode={borrelMode}
+            logo={settings?.progressBarLogo ? URL_PROGRESS_BAR_LOGO : ''}
+            progressBarColor={selectedPoster?.color || settings?.defaultProgressBarColor}
+            clockColor={selectedPoster?.color}
+            clockTick={settings?.clockShouldTick}
+          />
+        </div>
       </div>
-    </div>
+      <ChangeTrackOverlay socket={socket} />
+    </>
   );
 }

--- a/src/handlers/poster/StaticPosterView.tsx
+++ b/src/handlers/poster/StaticPosterView.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../api';
 import BackgroundStarryNight from '../../components/backgrounds/StarryNight';
 import { LogoCentered } from '../../components/aurora-logos/LogoCentered';
+import ChangeTrackOverlay from '../../overlays/ChangeTrackOverlay';
 import ImagePoster from './types/ImagePoster';
 import VideoPoster from './types/VideoPoster';
 import ExternalPoster from './types/ExternalPoster';
@@ -99,19 +100,22 @@ export default function StaticPosterView({ socket }: Props) {
   };
 
   return (
-    <div className="relative w-screen h-screen" id="poster">
-      <link rel="stylesheet" href="/src/handlers/poster/poster.css" />
-      {/* Custom stylesheet should be imported AFTER the base stylesheet,
-      because the precedence is that the last CSS definition will be used */}
-      {settings?.stylesheet && <link rel="stylesheet" href={URL_CUSTOM_STYLESHEET} />}
-      <div className="overflow-hidden absolute w-full h-full">{renderPoster()}</div>
-      {clock && (
-        <ProgressBar
-          logo={settings?.progressBarLogo ? URL_PROGRESS_BAR_LOGO : ''}
-          clockTick={settings?.clockShouldTick}
-          minimal={settings?.defaultMinimal}
-        />
-      )}
-    </div>
+    <>
+      <div className="relative w-screen h-screen" id="poster">
+        <link rel="stylesheet" href="/src/handlers/poster/poster.css" />
+        {/* Custom stylesheet should be imported AFTER the base stylesheet,
+        because the precedence is that the last CSS definition will be used */}
+        {settings?.stylesheet && <link rel="stylesheet" href={URL_CUSTOM_STYLESHEET} />}
+        <div className="overflow-hidden absolute w-full h-full">{renderPoster()}</div>
+        {clock && (
+          <ProgressBar
+            logo={settings?.progressBarLogo ? URL_PROGRESS_BAR_LOGO : ''}
+            clockTick={settings?.clockShouldTick}
+            minimal={settings?.defaultMinimal}
+          />
+        )}
+      </div>
+      <ChangeTrackOverlay socket={socket} />
+    </>
   );
 }

--- a/src/overlays/ChangeTrackOverlay.tsx
+++ b/src/overlays/ChangeTrackOverlay.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { Socket } from 'socket.io-client';
+import { AnimatePresence, motion } from 'framer-motion';
+import GlassCard from '../components/GlassCard';
+import { TrackChangeEvent } from '../api';
+
+const TIME_VISIBLE_MS = 8000;
+
+interface Props {
+  socket: Socket;
+}
+
+export default function ChangeTrackOverlay({ socket }: Props) {
+  const [visible, setVisible] = useState(false);
+  const [songs, setSongs] = useState<TrackChangeEvent[]>([]);
+
+  useEffect(() => {
+    const handleEvent = ([event]: TrackChangeEvent[][]) => {
+      console.info(event);
+      setSongs(event);
+      setVisible(true);
+      setTimeout(() => {
+        setVisible(false);
+      }, TIME_VISIBLE_MS);
+    };
+
+    socket.on('change_track', handleEvent);
+
+    return () => {
+      socket.off('change_track', handleEvent);
+    };
+  }, [socket]);
+
+  const renderSongs = () => {
+    if (songs.length === 0) return null;
+    const title = songs.map((song) => song.title).join(' - ');
+    const artists = songs.map((song) => song.artists.join(', ')).join(' - ');
+
+    return (
+      <div className="flex flex-row gap-[1.5vw] items-center">
+        <img src={songs[0].cover} className="h-[10vh]" alt="" />
+        <div className="flex flex-col">
+          <p className="text-[3vh]">{title}</p>
+          <p className="text-[2vh]">{artists}</p>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="overflow-hidden absolute w-full h-full top-0">
+      <AnimatePresence>
+        {visible && (
+          <motion.div
+            className="absolute w-full -bottom-[2.5vw] p-[1.75vw] flex items-center justify-center text-white z-100"
+            initial={{ y: '20vh' }}
+            animate={{ y: 0, transition: { duration: 1 } }}
+            exit={{ y: '20vh', transition: { duration: 1 } }}
+          >
+            <GlassCard className="pt-[1vw] pb-[2vw] px-[1.75vw] z-100">{renderSongs()}</GlassCard>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds an overlay to show what song is currently playing, when it changes.

![image](https://github.com/user-attachments/assets/3d883b42-61f8-42c9-be69-feeb90d19bf5)


## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Fixes https://github.com/GEWIS/aurora-client/issues/14.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_