### PR TITLE
feat: add support for the new screen scaling to natively support higher-resolution displays

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import AuthContextProvider from './contexts/AuthContext';
 import ErrorBoundary from './ErrorBoundary';
 import { client } from './api/client.gen';
 import ClientView from './ClientView';
+import AutoScaler from './components/AutoScaler';
 export default function App() {
   client.setConfig({
     baseUrl: '/api',
@@ -13,6 +14,7 @@ export default function App() {
     <ErrorBoundary>
       <BrowserRouter>
         <AuthContextProvider>
+          <AutoScaler />
           <ClientView />
         </AuthContextProvider>
       </BrowserRouter>

--- a/src/components/AutoScaler.tsx
+++ b/src/components/AutoScaler.tsx
@@ -1,0 +1,31 @@
+import { useContext, useEffect, useState } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
+import { getOwnScreen, ScreenResponse } from '../api';
+
+const DEFAULT_FONT_SIZE = 16;
+
+export default function AutoScaler() {
+  const { user } = useContext(AuthContext);
+
+  const [screen, setScreen] = useState<ScreenResponse | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+
+    getOwnScreen()
+      .then((res) => {
+        if (res.response.ok && res.data) {
+          setScreen(res.data);
+        }
+      })
+      .catch(console.error);
+  }, [user]);
+
+  useEffect(() => {
+    if (screen) {
+      document.documentElement.style.fontSize = Math.round(DEFAULT_FONT_SIZE * screen.scaleFactor) + 'px';
+    }
+  }, [screen]);
+
+  return null;
+}

--- a/src/components/OrderList.tsx
+++ b/src/components/OrderList.tsx
@@ -21,24 +21,24 @@ export default function OrderList({ orders }: Props) {
 
   return (
     // bg-blue-500
-    <div className="absolute top-0 right-0 z-50 m-[1.5vh] text-white" style={{ height: '85%', fontSize: '5.5vh' }}>
+    <div className="absolute top-0 right-0 z-50 m-4 text-white h-10/12 text-6xl">
       <div>
         <AnimatePresence>
           {orders.length > 0 && (
             <motion.div initial={animationInitial} animate={animationIn} exit={animationOut}>
-              <GlassCard className="top-0 right-0 mb-[1.5vh] px-[2vh] py-[1.5vh] text-center">Ready</GlassCard>
+              <GlassCard className="top-0 right-0 mb-5 px-4 py-7 text-center">Ready</GlassCard>
             </motion.div>
           )}
         </AnimatePresence>
         <ul
-          className="grid grid-flow-col-dense gap-[1.5vh]"
+          className="grid grid-flow-col-dense gap-5"
           style={{ gridTemplateRows: 'repeat(6, minmax(0, 1fr))' }}
           dir="rtl"
         >
           <AnimatePresence>
             {orders.map((order) => (
               <motion.li key={order.number} initial={animationInitial} animate={animationIn} exit={animationOut} layout>
-                <GlassCard className="text-center p-[1.5vh] min-w-[2.3em]">{order.number}</GlassCard>
+                <GlassCard className="text-center px-4 py-7 min-w-36">{order.number}</GlassCard>
               </motion.li>
             ))}
           </AnimatePresence>

--- a/src/handlers/poster/CarouselPosterView.tsx
+++ b/src/handlers/poster/CarouselPosterView.tsx
@@ -95,9 +95,6 @@ export default function CarouselPosterView({ socket }: Props) {
         style={{ backgroundImage: 'url("base/poster-background.png")' }}
         id="poster"
       >
-        <link rel="stylesheet" href="/src/handlers/poster/poster.css" />
-        {/* Custom stylesheet should be imported AFTER the base stylesheet,
-      because the precedence is that the last CSS definition will be used */}
         {settings?.stylesheet && <link rel="stylesheet" href={URL_CUSTOM_STYLESHEET} />}
         <div className="overflow-hidden w-full h-full">
           <PosterCarousel posters={posters || []} currentPoster={!posterIndex ? 0 : posterIndex} setTitle={setTitle} />

--- a/src/handlers/poster/StaticPosterView.tsx
+++ b/src/handlers/poster/StaticPosterView.tsx
@@ -102,7 +102,6 @@ export default function StaticPosterView({ socket }: Props) {
   return (
     <>
       <div className="relative w-screen h-screen" id="poster">
-        <link rel="stylesheet" href="/src/handlers/poster/poster.css" />
         {/* Custom stylesheet should be imported AFTER the base stylesheet,
         because the precedence is that the last CSS definition will be used */}
         {settings?.stylesheet && <link rel="stylesheet" href={URL_CUSTOM_STYLESHEET} />}

--- a/src/handlers/poster/components/ProgressBar.tsx
+++ b/src/handlers/poster/components/ProgressBar.tsx
@@ -39,28 +39,37 @@ export default function ProgressBar({
         </div>
       )}
       <div
-        className="relative text-white flex flex-col text-5xl progress-bar-height"
+        className="relative text-white flex flex-col text-5xl h-20 progress-bar-height"
         id="progress-bar"
         style={{ backgroundColor: !minimal && !hide ? 'rgba(0, 0, 0, 0.5)' : '' }}
       >
-        <div className="absolute w-full" style={{ bottom: minimal || hide ? 0 : '' }} id="progress-bar-slider-outer">
+        <div
+          className="absolute w-full h-1.5 mt-[-0.2rem]"
+          style={{ bottom: minimal || hide ? 0 : '' }}
+          id="progress-bar-slider-outer"
+        >
           {seconds !== undefined && posterIndex !== undefined && (
             <ProgressBarSlider seconds={seconds} posterIndex={posterIndex} color={progressBarColor} />
           )}
         </div>
         <div
-          className={`flex-grow flex justify-center items-center h-full ${hide ? 'hidden' : ''}`}
+          className={`flex-grow flex justify-center items-center h-full px-6 ${hide ? 'hidden' : ''}`}
           id="progress-bar-container"
         >
-          <div className="relative py-3" id="progress-bar-logos">
+          <div className="relative py-3 h-full w-1/5" id="progress-bar-logos">
             <div className="h-full flex flex-row gap-6 items-center">
               {logo && (
                 <>
-                  <svg style={{ filter: 'drop-shadow(3px 5px 2px rgb(0 0 0 /0.4))' }} viewBox="0 0 50 100">
+                  <svg
+                    className="h-12"
+                    style={{ filter: 'drop-shadow(3px 5px 2px rgb(0 0 0 /0.4))' }}
+                    viewBox="0 0 50 100"
+                  >
                     <image x="0" y="0" height="100%" width="100%" xlinkHref={logo} />
                   </svg>
                   {borrelMode && (
                     <svg
+                      className="h-10"
                       style={{
                         filter: 'brightness(0) invert(1) drop-shadow(3px 5px 2px rgb(0 0 0 /0.4))',
                       }}

--- a/src/handlers/poster/components/ProgressBar.tsx
+++ b/src/handlers/poster/components/ProgressBar.tsx
@@ -44,7 +44,7 @@ export default function ProgressBar({
         style={{ backgroundColor: !minimal && !hide ? 'rgba(0, 0, 0, 0.5)' : '' }}
       >
         <div
-          className="absolute w-full h-1.5 mt-[-0.2rem]"
+          className="absolute w-full h-1.5 -mt-1"
           style={{ bottom: minimal || hide ? 0 : '' }}
           id="progress-bar-slider-outer"
         >

--- a/src/handlers/poster/poster.css
+++ b/src/handlers/poster/poster.css
@@ -1,6 +1,5 @@
 /* Height of the progress bar */
 .progress-bar-height {
-  height: 7.5vh;
 }
 
 /* All progress bar elements */
@@ -9,14 +8,10 @@
 
 /* Aurora Watermark shown on the first poster of the carousel. Hidden otherwise */
 #poster #progress-bar #watermark {
-  /*You probably want to set some custom size if you rescale everything
-  /*font-size: '2em';*/
 }
 
 /* The full-width box the slider is contained in */
 #poster #progress-bar #progress-bar-slider-outer {
-  height: 6.25%;
-  margin-top: -0.1%;
 }
 
 /* The slider showing the progress of the poster */
@@ -25,25 +20,18 @@
 
 /* The semi-opaque contents of the progress bar */
 #poster #progress-bar #progress-bar-container {
-  padding: 0 1.25vw;
 }
 
 /* The outer div containing one or more logos */
 #poster #progress-bar #progress-bar-container #progress-bar-logos {
-  height: 100%;
-  width: 20vw;
 }
 
 /* Your uploaded logo */
 #poster #progress-bar #progress-bar-container #progress-bar-logos svg:first-child {
-  /*height: 88%;*/
-  height: 4.6vh;
 }
 
 /* The borrel mode logo (SudoSOS) */
 #poster #progress-bar #progress-bar-container #progress-bar-logos svg#progress-bar-logo-borrelmode {
-  /*height: 70%;*/
-  height: 3.7vh;
 }
 
 /* The div containing the title in the progress bar */
@@ -52,6 +40,4 @@
 
 /* The div containing the clock of the progress bar */
 #poster #progress-bar #progress-bar-container #progress-bar-clock {
-  width: 20vw;
-  font-size: 4.4vh;
 }

--- a/src/overlays/ChangeTrackOverlay.tsx
+++ b/src/overlays/ChangeTrackOverlay.tsx
@@ -37,11 +37,11 @@ export default function ChangeTrackOverlay({ socket }: Props) {
     const artists = songs.map((song) => song.artists.join(', ')).join(' - ');
 
     return (
-      <div className="flex flex-row gap-[1.5vw] items-center">
-        <img src={songs[0].cover} className="h-[10vh]" alt="" />
+      <div className="flex flex-row gap-8 items-center">
+        <img src={songs[0].cover} className="h-28" alt="" />
         <div className="flex flex-col">
-          <p className="text-[3vh]">{title}</p>
-          <p className="text-[2vh]">{artists}</p>
+          <p className="text-3xl">{title}</p>
+          <p className="text-xl">{artists}</p>
         </div>
       </div>
     );
@@ -52,12 +52,12 @@ export default function ChangeTrackOverlay({ socket }: Props) {
       <AnimatePresence>
         {visible && (
           <motion.div
-            className="absolute w-full -bottom-[2.5vw] p-[1.75vw] flex items-center justify-center text-white z-100"
+            className="absolute w-full -bottom-12 py-8 px-48 flex items-center justify-center text-white z-100"
             initial={{ y: '20vh' }}
             animate={{ y: 0, transition: { duration: 1 } }}
             exit={{ y: '20vh', transition: { duration: 1 } }}
           >
-            <GlassCard className="pt-[1vw] pb-[2vw] px-[1.75vw] z-100">{renderSongs()}</GlassCard>
+            <GlassCard className="pt-5 pb-10 px-8 z-100">{renderSongs()}</GlassCard>
           </motion.div>
         )}
       </AnimatePresence>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
This PR adds support for the new `scalingFactor` attribute of screen entities.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Fixes https://github.com/GEWIS/aurora-client/issues/68. The file that caused this problem is no longer used. It is not just a template.
Fixes https://github.com/GEWIS/aurora-client/issues/52. Because some components scaled to screen width/height. This is no longer the case, so setting a display in portrait should work as expected.
Depends on https://github.com/GEWIS/aurora-core/pull/127.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_